### PR TITLE
Remove 1 px from max to avoid overlapping target

### DIFF
--- a/src/media/media.ts
+++ b/src/media/media.ts
@@ -29,7 +29,7 @@ const media: MediaObject = (Object.keys(defaultBreakpoints) as Media[]).reduce(
     `;
 
     const maxMedia: MediaTagFunction = (strings, ...interpolations) => css`
-      @media (max-width: ${props => getBreakpoints(props)[label]}px) {
+      @media (max-width: ${props => (getBreakpoints(props)[label] - 1)}px) {
         ${css(strings as CSSObject | TemplateStringsArray, ...interpolations)}
       }
     `;


### PR DESCRIPTION
Motivation: If we want to toggle 2 columns depending on a breakpoint we write
```
<Col hiddenMdUp>Should Hide on larger than MD</Col>
<Col hiddenMdDown>Should Hide on smaller than MD</Col>
```
It usually works but if the screen width is exactly = MD then both hides. Changing one of them by 1 pixel should solve this problem.